### PR TITLE
Adds install target in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,5 +16,8 @@ hfp_tcp:	hfp_tcp_server.c
 		$(info Building for $(OS))
 		$(CC) -I$(HH) hfp_tcp_server.c -o hfp_tcp $(STD) -lm -lairspyhf
 
+install:	hfp_tcp
+		cp ./hfp_tcp /usr/local/bin
+
 clean: 
 	rm hfp_tcp


### PR DESCRIPTION
The install target copies the hfp_tcp executable to /usr/local/bin.