### PR TITLE
Adds pthread to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 OS := $(shell uname)
-HH = /usr/local/include/libairspyhf 
+HH = /usr/local/include/libairspyhf
 
 ifeq ($(OS), Darwin)
 	CC  = clang
+	LL  = -lpthread
 else
 ifeq ($(OS), Linux)
 	CC  = cc
+	LL = -pthread
 	STD = -std=c99
 else
 	$(error OS not detected)
@@ -14,10 +16,10 @@ endif
 
 hfp_tcp:	hfp_tcp_server.c
 		$(info Building for $(OS))
-		$(CC) -I$(HH) hfp_tcp_server.c -o hfp_tcp $(STD) -lm -lairspyhf
+		$(CC) -I$(HH) hfp_tcp_server.c $(LL) -o hfp_tcp $(STD) -lm -lairspyhf
 
 install:	hfp_tcp
 		cp ./hfp_tcp /usr/local/bin
 
-clean: 
+clean:
 	rm hfp_tcp


### PR DESCRIPTION
Adds pthread to makefile

Compiles on Pi:

~/SDR/hfp_tcp(master) $ git checkout makefilefix
Branch makefilefix set up to track remote branch makefilefix from bitbucket.
Switched to a new branch 'makefilefix'
~/SDR/hfp_tcp(makefilefix) $ make
Building for Linux
cc -I/usr/local/include/libairspyhf hfp_tcp_server.c -pthread -o hfp_tcp -std=c99 -lm -lairspyhf
~/SDR/hfp_tcp(makefilefix) $ 

Compiles on Mac:

~/Local/SDR/hfp_tcp(makefilefix) $ make hfp_tcp
Building for Darwin
clang -I/usr/local/include/libairspyhf hfp_tcp_server.c -lpthread -o hfp_tcp  -lm -lairspyhf
hfp_tcp_server.c:407:32: warning: passing 'uint8_t [131072]' to parameter of type 'char *' converts between pointers to integer types with different
      sign [-Wpointer-sign]
            int sz = ring_read(tmpBuf, sz0, 0);
                               ^~~~~~
hfp_tcp_server.c:355:21: note: passing argument to parameter 'to_ptr' here
int ring_read(char *to_ptr, int amount, int always)
                    ^
1 warning generated.
~/Local/SDR/hfp_tcp(makefilefix) $